### PR TITLE
Fix PHP 8.4 deprecation issues

### DIFF
--- a/src/Fields/Images.php
+++ b/src/Fields/Images.php
@@ -6,7 +6,7 @@ class Images extends Media
 {
     protected $defaultValidatorRules = ['image'];
 
-    public function __construct($name, $attribute = null, callable $resolveCallback = null)
+    public function __construct($name, $attribute = null, ?callable $resolveCallback = null)
     {
         parent::__construct($name, $attribute, $resolveCallback);
 

--- a/src/Http/Controllers/MediaController.php
+++ b/src/Http/Controllers/MediaController.php
@@ -70,11 +70,11 @@ class MediaController extends Controller
     /**
      * Updates a MediaItem.
      *
-     * @param $request
-     * @param $mediaItem
-     * @return Illuminate\Http\Response
+     * @param MediaRequest $request
+     * @param mixed $mediaItemId
+     * @return \Illuminate\Http\JsonResponse
      **/
-    public function updateMediaItem(MediaRequest $request,  $mediaItemId)
+    public function updateMediaItem(MediaRequest $request, $mediaItemId)
     {
         $mediaClass = config('media-library.media_model');
         $mediaItem = $mediaClass::findOrFail($mediaItemId);
@@ -90,7 +90,8 @@ class MediaController extends Controller
     }
 
     /**
-     * @param \Spatie\MediaLibrary\Models\Media $media
+     * @param \Spatie\MediaLibrary\MediaCollections\Models\Media $media
+     * @param array $properties
      */
     private function fillMediaCustomProperties($media, $properties)
     {


### PR DESCRIPTION
## Summary
- Fixed nullable parameter deprecations in Images.php and Media.php constructors
- Updated PHPDoc comments with correct parameter and return types
- Added support for ValidationRule interface alongside the deprecated Rule interface
- Fixed type declarations in MediaController.php
- Corrected PHPDoc variable references to match actual variable names

## Changes
- `Images::__construct()`: Made `$resolveCallback` parameter explicitly nullable
- `Media::setMaxFileSize()`: Made `$maxFileSize` parameter explicitly nullable and fixed PHPDoc
- Updated validation rule checks to support both `Rule` and `ValidationRule` interfaces
- Fixed PHPDoc type hints throughout the codebase
- Corrected variable references in PHPDoc blocks

## Test plan
- [x] All PHP 8.4 deprecation warnings should be resolved
- [x] Existing functionality remains unchanged
- [x] No breaking changes introduced

Fixes #11