### PR TITLE
Fix resolve method signature - Remove string type hint from attribute parameter

### DIFF
--- a/src/Fields/Media.php
+++ b/src/Fields/Media.php
@@ -292,7 +292,7 @@ class Media extends Field
      * @param HasMedia $resource
      * @param string|null $attribute
      */
-    public function resolve($resource, ?string $attribute = null): void
+    public function resolve($resource, $attribute = null): void
     {
         $collectionName = $attribute ?? $this->attribute;
 


### PR DESCRIPTION
## Summary

This PR fixes the signature issue for the `resolve` method in `Media.php` by removing the string type hint from the $attribute parameter.

## Changes
- Changed method signature from `resolve($resource, ?string $attribute = null)` to `resolve($resource, $attribute = null)`
- Maintains compatibility while fixing the signature issue

## Fixes
- Closes #14

## Test plan
- [x] Method signature updated correctly
- [x] No breaking changes to existing functionality
- [x] Maintains backward compatibility